### PR TITLE
Bo1 : Implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,11 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	implementation 'org.jsoup:jsoup:1.17.2'
+
+	implementation 'com.rometools:rome:1.10.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fitnews/fit_news/news/controller/NewsController.java
+++ b/src/main/java/com/fitnews/fit_news/news/controller/NewsController.java
@@ -1,7 +1,7 @@
 package com.fitnews.fit_news.news.controller;
 
 import com.fitnews.fit_news.news.entity.News;
-import com.fitnews.fit_news.news.service.NewsService;
+import com.fitnews.fit_news.news.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -14,6 +14,11 @@ import java.util.List;
 public class NewsController {
 
     private final NewsService newsService;
+    private final NewsClassificationService newsClassificationService;
+    private final NewsCrawlingService newsCrawlingService;
+    private final NewsRecommendationService newsRecommendationService;
+    private final NewsScheduler newsScheduler;
+    private final OpenAIAPIService openAIAPIService;
 
     @GetMapping("/news")
     public String newsList(Model model) {

--- a/src/main/java/com/fitnews/fit_news/news/model/NewsData.java
+++ b/src/main/java/com/fitnews/fit_news/news/model/NewsData.java
@@ -1,0 +1,29 @@
+package com.fitnews.fit_news.news.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class NewsData {
+    private String title;
+    private String link;
+    private String description;
+
+    private Tc newsTc=null;
+    private Boolean isClassified=false;
+
+    public NewsData(String title, String link, String description){
+        this.title=title;
+        this.link=link;
+        this.description=description;
+    }
+
+    @Override
+    public String toString(){
+        return title;
+    }
+
+}

--- a/src/main/java/com/fitnews/fit_news/news/model/NewsData.java
+++ b/src/main/java/com/fitnews/fit_news/news/model/NewsData.java
@@ -21,9 +21,15 @@ public class NewsData {
         this.description=description;
     }
 
+    public void setTc(Tc newsTc){
+        this.newsTc=newsTc;
+    }
+
     @Override
     public String toString(){
-        return title;
+        if(newsTc!=null)
+            return title+description+newsTc.getAge()+newsTc.getZender()+newsTc.getPolitic();
+        return title+description;
     }
 
 }

--- a/src/main/java/com/fitnews/fit_news/news/model/Tc.java
+++ b/src/main/java/com/fitnews/fit_news/news/model/Tc.java
@@ -1,0 +1,23 @@
+package com.fitnews.fit_news.news.model;
+
+/*
+Tendency 클래스
+ */
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class Tc {
+    // 성별 지향성 (0=여성향, 100=남성향)
+    private int zender=50;
+
+    // 정치 성향 (0=보수, 100=진보)
+    private int politic=50;
+
+    // 연령대 (a=미성년자, b=청년, c=중년, d=노년)
+    private char age='b';
+}

--- a/src/main/java/com/fitnews/fit_news/news/model/Tc.java
+++ b/src/main/java/com/fitnews/fit_news/news/model/Tc.java
@@ -12,12 +12,15 @@ import lombok.Setter;
 @Setter
 @RequiredArgsConstructor
 public class Tc {
+    // Json응답 파싱을 위한 인덱스 정보
+    private int index;
+
     // 성별 지향성 (0=여성향, 100=남성향)
-    private int zender=50;
+    private int zender;
 
     // 정치 성향 (0=보수, 100=진보)
-    private int politic=50;
+    private int politic;
 
     // 연령대 (a=미성년자, b=청년, c=중년, d=노년)
-    private char age='b';
+    private char age;
 }

--- a/src/main/java/com/fitnews/fit_news/news/model/UserInfo.java
+++ b/src/main/java/com/fitnews/fit_news/news/model/UserInfo.java
@@ -1,0 +1,18 @@
+package com.fitnews.fit_news.news.model;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+/*
+뉴스 도메인에서 사용할 사용자 정보 DTO
+ */
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class UserInfo {
+    private Long userId;
+    private String username;
+    private Tc userTc;
+}

--- a/src/main/java/com/fitnews/fit_news/news/service/NewsClassificationService.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/NewsClassificationService.java
@@ -1,0 +1,97 @@
+package com.fitnews.fit_news.news.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fitnews.fit_news.news.model.NewsData;
+import com.fitnews.fit_news.news.model.Tc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+/*
+preprocessingNews : 크롤러에서 넘어온 raw news를 전처리(프롬프트화)
+postprocessingNews : OpenAI API에서 넘어온 news를 후처리(NewsData화)
+
+입/출력 : List<NewsData>
+ */
+
+@Service
+public class NewsClassificationService {
+    private static final Logger logger =
+            LoggerFactory.getLogger(NewsClassificationService.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 전처리
+    String preprocessingNews(List<NewsData> newsData){
+        if (newsData == null) return "";
+        logger.info("Preprocessing {} news items", newsData.size());
+
+        // TODO 전처리 로직 : Build Prompt
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("""
+        You are an AI model that classifies news articles based on three attributes:
+        1. zender (0-100): 0 means female-oriented, 100 means male-oriented.
+        2. politic (0-100): 0 means conservative, 100 means progressive.
+        3. age (a/b/c/d): a=minor, b=young adult, c=middle-aged, d=senior.
+
+        ⚠️ Respond ONLY in this JSON array format:
+        [
+          {"index":1, "zender":int, "politic":int, "age":"a|b|c|d"},
+          {"index":2, "zender":int, "politic":int, "age":"a|b|c|d"}
+        ]
+
+        Below are the news items to classify:
+        """);
+
+        int index=1;
+        for (NewsData news : newsData) {
+            prompt.append(String.format("""
+                
+                [%d]
+                Title: %s
+                Description: %s
+                """,
+                    index++,
+                    news.getTitle(),
+                    news.getDescription() != null ? news.getDescription() : "No description"));
+        }
+
+        prompt.append("\nNow, provide classification results ONLY in JSON array.\n");
+
+        logger.info("After Preprocessing {} news items", newsData.size());
+        return prompt.toString();
+    }
+
+    /**
+     * GPT 응답(JSON)을 기반으로 각 NewsData에 Classification 결과(Tc)를 주입
+     *
+     * @param response GPT 응답 문자열 (JSON Array 형식)
+     * @param newsData 분류 대상 뉴스 목록
+     * @return Tc 정보가 포함된 뉴스 리스트
+     */
+    List<NewsData> postprocessingNews(String response, List<NewsData> newsData){
+        if (newsData == null) return Collections.emptyList();
+        logger.info("Postprocessing {} news items", newsData.size());
+
+        // TODO 후처리 로직
+        try{
+            // GPT 응답을 List<Tc> 형태로 파싱
+            List<Tc> classifications = objectMapper.readValue(response, new TypeReference<List<Tc>>() {});
+
+            // 뉴스 개수와 분류 결과 개수가 동일할 때 매핑
+            for (int i = 0; i < newsData.size() && i < classifications.size(); i++) {
+                newsData.get(i).setNewsTc(classifications.get(i));
+            }
+
+            logger.info("After Postprocessing {} news items", newsData.size());
+
+            return newsData;
+        } catch (Exception e){
+            throw new RuntimeException("❌ Classification 파싱 실패: " + e.getMessage(), e);
+        }
+
+    }
+}

--- a/src/main/java/com/fitnews/fit_news/news/service/NewsClassificationService.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/NewsClassificationService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /*
 preprocessingNews : 크롤러에서 넘어온 raw news를 전처리(프롬프트화)
@@ -29,7 +30,7 @@ public class NewsClassificationService {
         if (newsData == null) return "";
         logger.info("Preprocessing {} news items", newsData.size());
 
-        // TODO 전처리 로직 : Build Prompt
+        // BuildPrompt
         StringBuilder prompt = new StringBuilder();
         prompt.append("""
         You are an AI model that classifies news articles based on three attributes:
@@ -76,14 +77,14 @@ public class NewsClassificationService {
         if (newsData == null) return Collections.emptyList();
         logger.info("Postprocessing {} news items", newsData.size());
 
-        // TODO 후처리 로직
         try{
-            // GPT 응답을 List<Tc> 형태로 파싱
-            List<Tc> classifications = objectMapper.readValue(response, new TypeReference<List<Tc>>() {});
+            List<Tc> tcList = objectMapper.readValue(
+                    response, new TypeReference<List<Tc>>() {}
+            );
 
-            // 뉴스 개수와 분류 결과 개수가 동일할 때 매핑
-            for (int i = 0; i < newsData.size() && i < classifications.size(); i++) {
-                newsData.get(i).setNewsTc(classifications.get(i));
+            for (Tc tc : tcList){
+                int index = tc.getIndex()-1;
+                newsData.get(index).setTc(tc);
             }
 
             logger.info("After Postprocessing {} news items", newsData.size());

--- a/src/main/java/com/fitnews/fit_news/news/service/NewsCrawlingService.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/NewsCrawlingService.java
@@ -1,0 +1,82 @@
+package com.fitnews.fit_news.news.service;
+
+import com.fitnews.fit_news.news.model.NewsData;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.FeedException;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Component
+public class NewsCrawlingService {
+    private static final Logger logger =
+            LoggerFactory.getLogger(NewsCrawlingService.class);
+    String Base_Url = "https://news-ex.jtbc.co.kr/v1/get/rss/section/";
+    static final String[] SECTIONS = {
+            "politics",
+            "economy",
+            "society",
+            "international",
+            "culture",
+            "entertaining",
+            "sports",
+            "weather"
+    };
+
+    public NewsCrawlingService() throws FeedException, IOException {
+    }
+
+    public List<NewsData> crawlingNews(long crawlingTime) throws IOException {
+        logger.info("Crawling started. crawlingTime(epoch ms) = {}", crawlingTime);
+
+        List<NewsData> crawledNews = new ArrayList<>();
+
+        for(String section : SECTIONS){
+            String feedUrl = Base_Url+section;
+
+            try{
+                URL url = new URL(feedUrl);
+                SyndFeedInput input = new SyndFeedInput();
+                SyndFeed feed = input.build(new XmlReader(url));
+
+                logger.info("Fetching section: {}", section);
+
+                for (SyndEntry entry : feed.getEntries()) {
+                    String title = entry.getTitle();
+                    String link = entry.getLink();
+                    String description = entry.getDescription() != null
+                            ? entry.getDescription().getValue()
+                            : "No description available";
+
+                    crawledNews.add(new NewsData(title, link, description));
+                }
+            } catch(Exception e){
+                logger.error("Error while fetching section: {}", section, e);
+            }
+        }
+
+        logger.info("Crawling finished. found {} items", crawledNews.size());
+        // TEST
+        System.out.println("\n 뉴스 출력");
+        for(NewsData news : crawledNews){
+            System.out.println(news);
+        }
+
+        return crawledNews;
+    }
+}

--- a/src/main/java/com/fitnews/fit_news/news/service/NewsCrawlingService.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/NewsCrawlingService.java
@@ -29,13 +29,13 @@ public class NewsCrawlingService {
     String Base_Url = "https://news-ex.jtbc.co.kr/v1/get/rss/section/";
     static final String[] SECTIONS = {
             "politics",
-            "economy",
-            "society",
-            "international",
-            "culture",
-            "entertaining",
-            "sports",
-            "weather"
+//            "economy",
+//            "society",
+//            "international",
+//            "culture",
+//            "entertaining",
+//            "sports",
+//            "weather"
     };
 
     public NewsCrawlingService() throws FeedException, IOException {
@@ -72,10 +72,10 @@ public class NewsCrawlingService {
 
         logger.info("Crawling finished. found {} items", crawledNews.size());
         // TEST
-        System.out.println("\n 뉴스 출력");
-        for(NewsData news : crawledNews){
-            System.out.println(news);
-        }
+//        System.out.println("\n 뉴스 출력");
+//        for(NewsData news : crawledNews){
+//            System.out.println(news);
+//        }
 
         return crawledNews;
     }

--- a/src/main/java/com/fitnews/fit_news/news/service/NewsRecommendationService.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/NewsRecommendationService.java
@@ -1,0 +1,38 @@
+package com.fitnews.fit_news.news.service;
+
+/*
+추천 점수 척도 : UserTC와 NewsTC간의 거리
+추천 점수 기준 내림차순 정렬 후 상위 N개 반환
+ */
+
+import com.fitnews.fit_news.news.model.UserInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fitnews.fit_news.news.model.NewsData;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class NewsRecommendationService {
+    private static final Logger logger =
+            LoggerFactory.getLogger(NewsRecommendationService.class);
+
+    public List<NewsData> createNewsReco(List<NewsData> newsData, UserInfo userInfo){
+        if (newsData == null || newsData.isEmpty()) return Collections.emptyList();
+        if (userInfo == null) {
+            // 사용자 정보가 없으면 최신 뉴스(최대 10개) 반환
+            return newsData.stream().limit(10).toList();
+        }
+
+        // TODO 점수 계산
+
+        // TODO 정렬: 점수 내림차순
+
+        //logger.info("Created {} recommendations for user {}", result.size(), userInfo.getUserId());
+        return null;
+    }
+
+}

--- a/src/main/java/com/fitnews/fit_news/news/service/NewsScheduler.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/NewsScheduler.java
@@ -41,17 +41,24 @@ public class NewsScheduler {
                 logger.info("No new news items found at {}", crawlingTime);
                 return;
             }
+            logger.info("✅ 1 Crawling Clear");
 
             //2 Classification
+            String preprocessedNews = newsClassificationService.preprocessingNews(rawNews);
+            logger.info("✅ 2 Preprocessing Success");
+
+            String response= openAIAPIService.askChatGPT(preprocessedNews);
+            logger.info("✅ 3 Request Success");
+
             List<NewsData> classifiedNews
-                    = newsClassificationService.postprocessingNews(
-                    openAIAPIService.askChatGPT(newsClassificationService.preprocessingNews(rawNews)),
-                    rawNews
-            );
+                    = newsClassificationService.postprocessingNews(response, rawNews);
+            logger.info("✅ 4 PostProcessing Success");
+//            for(NewsData newsData : classifiedNews){
+//                System.out.println(newsData.toString());
+//            }
 
             //3 Saving
-            // TODO : 전처리된 뉴스 저장
-
+            // TODO : 분류된 뉴스 저장
             logger.info("Saved {} news items from crawling at {}", classifiedNews.size(), crawlingTime);
 
         } catch(Exception e){

--- a/src/main/java/com/fitnews/fit_news/news/service/NewsScheduler.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/NewsScheduler.java
@@ -1,0 +1,61 @@
+package com.fitnews.fit_news.news.service;
+
+import com.fitnews.fit_news.news.model.NewsData;
+import com.fitnews.fit_news.news.repository.NewsRepository;
+import com.fitnews.fit_news.news.repository.NewsTendencyRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NewsScheduler {
+    private static final Logger logger
+            = LoggerFactory.getLogger(NewsScheduler.class);
+
+    private final NewsCrawlingService newsCrawlingService;
+    private final OpenAIAPIService openAIAPIService;
+    private final NewsClassificationService newsClassificationService;
+    // 레포지토리 선언
+    private static NewsRepository newsRepository;
+    private static NewsTendencyRepository newsTendencyRepository;
+
+    /*
+    fixedRate = 60000 -> 이전 시행 후 60초마다 시행(서버시간 기준)
+     */
+    @Scheduled(fixedRate = 60_000)
+    public void runCrawlingJob(){
+        long crawlingTime = Instant.now().toEpochMilli();
+        logger.info("NewsScheduler triggered at {}", crawlingTime);
+
+        try{
+            //1 Crawling
+            List<NewsData> rawNews = newsCrawlingService.crawlingNews(crawlingTime);
+
+            if(rawNews==null || rawNews.isEmpty()){
+                logger.info("No new news items found at {}", crawlingTime);
+                return;
+            }
+
+            //2 Classification
+            List<NewsData> classifiedNews
+                    = newsClassificationService.postprocessingNews(
+                    openAIAPIService.askChatGPT(newsClassificationService.preprocessingNews(rawNews)),
+                    rawNews
+            );
+
+            //3 Saving
+            // TODO : 전처리된 뉴스 저장
+
+            logger.info("Saved {} news items from crawling at {}", classifiedNews.size(), crawlingTime);
+
+        } catch(Exception e){
+            logger.error("Error occurred during scheduled crawling: ", e);
+        }
+    }
+}

--- a/src/main/java/com/fitnews/fit_news/news/service/OpenAIAPIService.java
+++ b/src/main/java/com/fitnews/fit_news/news/service/OpenAIAPIService.java
@@ -1,0 +1,57 @@
+package com.fitnews.fit_news.news.service;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+
+/*
+전처리(프롬프트화)된 뉴스 데이터를 이용, OpenAI API와 통신
+ */
+
+@Service
+public class OpenAIAPIService {
+    private static final Logger logger =
+            LoggerFactory.getLogger(OpenAIAPIService.class);
+
+    // TODO request method
+    private String apiKey = "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";
+
+    @PostConstruct
+    public void init(){
+        System.out.println("✅ API Key Loaded: " + (apiKey != null ? "YES" : "NO"));
+    }
+
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("https://api.openai.com/v1/chat/completions")
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+
+    public String askChatGPT(String prompt) {
+        Map<String, Object> message = Map.of("role", "user", "content", prompt);
+        Map<String, Object> body = Map.of(
+                "model", "gpt-4",
+                "messages", List.of(message),
+                "temperature", 0.7
+        );
+
+        return webClient.post()
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .map(response -> {
+                    List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
+                    Map<String, Object> choice = choices.get(0);
+                    Map<String, Object> messageMap = (Map<String, Object>) choice.get("message");
+                    return (String) messageMap.get("content");
+                })
+                .block();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ spring.h2.console.path=/h2-console
 
 # JWT secret key
 jwt.secret=mySecretKey123
+
+# OpenAI API secret Key
+openai.api.key=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

--- a/src/test/java/com/fitnews/fit_news/news/NewsCrawlingServiceTest.java
+++ b/src/test/java/com/fitnews/fit_news/news/NewsCrawlingServiceTest.java
@@ -1,0 +1,44 @@
+package com.fitnews.fit_news.news;
+
+import com.fitnews.fit_news.news.service.NewsCrawlingService;
+import com.fitnews.fit_news.news.model.NewsData;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+public class NewsCrawlingServiceTest {
+    @Autowired
+    private NewsCrawlingService newsCrawlingService;
+
+    @Test
+    @DisplayName("JTBC 뉴스 크롤링 정상 동작 테스트")
+    void testNewsCrawlingService() throws IOException{
+        List<NewsData> newsList = newsCrawlingService.crawlingNews(0);
+
+        // 크롤링 결과가 비어 있지 않은지 확인
+        assertNotNull(newsList, "크롤링 결과가 null이면 안 됨");
+        assertFalse(newsList.isEmpty(), "뉴스 목록이 비어 있으면 안 됨");
+
+        // 최소한의 필드 유효성 검사
+        NewsData sample = newsList.get(0);
+        assertNotNull(sample.getTitle(), "뉴스 제목은 null이면 안 됨");
+        assertTrue(sample.getLink().startsWith("https://news.jtbc.co.kr"), "링크 형식이 올바르지 않음");
+
+        // 디버그 출력
+        System.out.println("✅ 수집된 뉴스 개수: " + newsList.size());
+        System.out.println("예시 뉴스 제목: " + sample.getTitle());
+        System.out.println("예시 링크: " + sample.getLink());
+    }
+
+}

--- a/src/test/java/com/fitnews/fit_news/news/NewsSchedulerTest.java
+++ b/src/test/java/com/fitnews/fit_news/news/NewsSchedulerTest.java
@@ -1,0 +1,23 @@
+package com.fitnews.fit_news.news;
+
+
+import com.fitnews.fit_news.news.service.NewsScheduler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+
+@SpringBootTest
+public class NewsSchedulerTest {
+    @Autowired
+    private NewsScheduler newsScheduler;
+
+    @Test
+    @DisplayName("뉴스 크롤링 로직 : 주기적 크롤링 -> 전처리 -> OpenAI API 요청 -> 후처리 -> 저장 테스트")
+    void testNewsSchedulerLogic() throws IOException{
+        newsScheduler.runCrawlingJob();
+    }
+
+}


### PR DESCRIPTION
Feat : News Domain Implementation : 
NewsScheduler[주기적 뉴스 크롤링 시퀀스 호출], NewsCrawlingService[RSS 뉴스 크롤링 -> NewsData로 저장], NewsClassificationService[크롤링된 뉴스 기반 프롬프트 생성, OpenAI API에게 요청/응답, 응답 기반 NewsData 수정(TC 추가)], OpenAIAPIService[OpenAIAPI 통신을 위한 서비스]

TODO 1 : 레포지토리 저장을 위해 내부 클래스인 NewsData를 정식 모델 News와 NewsTendency로 변환하는 로직 개발예정
-> NewsTendency 형식 수정 필요

TODO 2 : RecommendationService 구현 필요 -> Problem1, 2 해결 이후

Problem 1 : Crawling단계에서 가져온 모든 뉴스 데이터를 한 번에 OpenAI API에게 요청할 수 없음, 현재 뉴스 개수 제한중

Problem 2 : OpenAI API의 뉴스 성향 판정이 굉장히 소극적임 -> 거의 모든 뉴스를 중립에 가깝게 판정 -> 프롬프트 수정으로 해결 가능할지?